### PR TITLE
HAPI-833 - params_source support

### DIFF
--- a/igb_client/parse.py
+++ b/igb_client/parse.py
@@ -1,8 +1,8 @@
 from typing import Dict, Set
-from .parse_custom import params_parser
+from .parse_custom import params_extra_parser
 
 
-ROOT_FIELDS_CUSTOM_EXTRACT = {"params": params_parser}
+ROOT_FIELDS_CUSTOM_EXTRACT = {"params": params_extra_parser}
 
 
 def parse_igb_xml_payload(payload: Dict) -> Dict:

--- a/igb_client/parse.py
+++ b/igb_client/parse.py
@@ -1,4 +1,8 @@
-from typing import Dict
+from typing import Dict, Set
+from .parse_custom import params_parser
+
+
+ROOT_FIELDS_CUSTOM_EXTRACT = {"params": params_parser}
 
 
 def parse_igb_xml_payload(payload: Dict) -> Dict:
@@ -22,12 +26,15 @@ def parse_igb_xml_payload(payload: Dict) -> Dict:
         # end condition
         return payload
 
-    for key in payload.keys():
+    for key in list(payload.keys()):
         if key.lower() in ["facets", "credentials", "options", "params", "rules"]:
             # only a few tags are containers in IGB's XSD
             singular_key = key.rstrip("s")
             if not payload.get(key):
                 continue
+            # extract additional fields that would be overwritten/lost by next iteration
+            if key in ROOT_FIELDS_CUSTOM_EXTRACT:
+                payload.update(ROOT_FIELDS_CUSTOM_EXTRACT[key](payload))
             payload[key] = [
                 parse_igb_xml_payload(item[singular_key])
                 for item in payload[key]

--- a/igb_client/parse_custom.py
+++ b/igb_client/parse_custom.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List, Set
 from collections import defaultdict
 
 
-def params_parser(payload: Dict) -> Dict[str, List[Any]]:
+def params_extra_parser(payload: Dict) -> Dict[str, Dict]:
     """
-    Converts from:
+    Extracts params with special source mapping from:
     {
         "name": "\\IGB\\Property\\Custom\\Doelsite\\Vdab\\Sjabloon",
         "params": [
@@ -12,15 +12,21 @@ def params_parser(payload: Dict) -> Dict[str, List[Any]]:
             {"param": "term1"},
             {"param": "term2"},
             {"term1": {"field": "title"}},
-            {"term2": {"field": "description"}},
+            {"term2": {"facet": "IGB_Competenties"}},
         ],
     }
 
-    to:
+    As following:
     {
-        "term1": [{"field": "title"}],
-        "term2": [{"field": "description"}],
+        "params_source": {
+            "term1": {"field": "title"},
+            "term2": {"facet": "IGB_Competenties"},
+        }
     }
+    OR
+    {}
+
+    So that the original mapping the new data appended
     """
     ret = defaultdict(list)
     # extract all params names from the payload (eg: term, credentials)

--- a/igb_client/parse_custom.py
+++ b/igb_client/parse_custom.py
@@ -1,0 +1,45 @@
+from typing import Any, Dict, List, Set
+from collections import defaultdict
+
+
+def params_parser(payload: Dict) -> Dict[str, List[Any]]:
+    """
+    Converts from:
+    {
+        "name": "\\IGB\\Property\\Custom\\Doelsite\\Vdab\\Sjabloon",
+        "params": [
+            {"param": "credentials"},
+            {"param": "term1"},
+            {"param": "term2"},
+            {"term1": {"field": "title"}},
+            {"term2": {"field": "description"}},
+        ],
+    }
+
+    to:
+    {
+        "term1": [{"field": "title"}],
+        "term2": [{"field": "description"}],
+    }
+    """
+    ret = defaultdict(list)
+    # extract all params names from the payload (eg: term, credentials)
+    param_names: Set[str] = {
+        child["param"] for child in payload.get("params", []) if "param" in child
+    }
+    # for each param, check to see if we have a rule with it's name as key
+    for param_info in payload.get("params", []):
+        # check for {'term': {'field': 'title'}} when param_info=term
+        param_name_as_key = set(param_info.keys()).intersection(param_names)
+        if not param_name_as_key:
+            # the param name doesn't have a custom source, so we can skip it
+            continue
+        # we will be getting only the first value, since igb returns array for single value
+        param_name = param_name_as_key.pop()
+        ret[param_name] = param_info[param_name]
+
+    if ret:
+        return {
+            "params_source": dict(ret),
+        }
+    return {}


### PR DESCRIPTION
Unit tests in [`test_igb_client.py` ](https://github.com/vonq/pkb/pull/702/files#diff-4dca771315e860a38d9375c36feac13f3d4419de9a9234bae5dad14eefb7c6c7R1) in PKB (put there due to lack of pipelines here).

Takes care of ` {"term": {"field": "title"}},` and prevents overwrite

Converts from
```
{
    "facet": {
        "name": "IGB_Sjabloon",
        "label": "Competentie-sjabloon",
        "sort": "10",
        "required": "1",
        "type": "SELECT",
        "labels": {"default": "Competentie-sjabloon"},
        "children": [{"facet": "IGB_Competenties"}],
        "options": [],
        "custom": {
            "name": "\\IGB\\Property\\Custom\\Doelsite\\Vdab\\Sjabloon",
            "params": [
                {"param": "credentials"},
                {"param": "term"},
                {"term": {"field": "title"}},
            ],
        },
    }
}
```

into:

```
{
            "facet": {
                "name": "IGB_Sjabloon",
                "label": "Competentie-sjabloon",
                "sort": "10",
                "required": "1",
                "type": "SELECT",
                "labels": {"default": "Competentie-sjabloon"},
                "children": [{"facet": "IGB_Competenties"}],
                "options": [],
                "custom": {
                    "name": "\\IGB\\Property\\Custom\\Doelsite\\Vdab\\Sjabloon",
                    "params": ["credentials", "term"],
                    "params_source": {"term": {"field": "title"}},
                },
            }
        }
```